### PR TITLE
Make order validation error messages translatable.

### DIFF
--- a/Controller/Order/ValidateOrder.php
+++ b/Controller/Order/ValidateOrder.php
@@ -91,7 +91,7 @@ class ValidateOrder extends Update
 
     protected function respondWithError($message, $chooseShippingMethod = false, $extraData = [])
     {
-        $data = ['messages' => $message, "chooseShippingMethod" => $chooseShippingMethod, 'error' => true];
+        $data = ['messages' => __($message), "chooseShippingMethod" => $chooseShippingMethod, 'error' => true];
         $data = array_merge($data, $extraData);
         $this->getResponse()->setBody(json_encode($data));
         return false;


### PR DESCRIPTION
This is the improvement for ValidateOrder controller which makes validation error messages translatable instead of displaying them always in English on Checkout page.