### PR TITLE
Resolution for online refund

### DIFF
--- a/Model/Dibs/Order.php
+++ b/Model/Dibs/Order.php
@@ -376,6 +376,13 @@ class Order
     public function refundDibsPayment(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
         $chargeId = $payment->getAdditionalInformation('dibs_charge_id');
+        $creditMemo = $payment->getCreditMemo();
+        if($creditMemo){
+            $invoice = $creditMemo->getInvoice();
+            if($invoice){
+                $chargeId = $invoice->getTransactionId();
+            }
+        }
         if ($chargeId) {
             $creditMemo = $payment->getCreditMemo();
             $this->items->addDibsItemsByCreditMemo($creditMemo);


### PR DESCRIPTION
**Summary of the issue**
Unable to issue credit memo (online refund) for invoice. It would return the error
_**Refund amount must be less or equal to charged amount**_

**Steps to reproduce**

- Place an order with 2 distinct product items (with different prices)
- Create an invoice for each order items. (The first invoice should have a grand total greater than the second invoice)
- Create a credit memo for the first invoice

**Expected Result**

- Should be able to issue a credit memo for the first invoice.

**Actual Result**
- Unable to create a credit memo with message "Refund amount must be less or equal to charged amount"

**Reason:**
dibs_charge_id found in table sales_order_payment is getting updated with the latest generated transaction id upon creation of an invoice.